### PR TITLE
rpcclient: update requirements for `capstone`

### DIFF
--- a/src/rpcclient/requirements.txt
+++ b/src/rpcclient/requirements.txt
@@ -9,7 +9,7 @@ pygments
 objc_types_decoder
 pycrashreport>=1.0.2
 lief
-capstone<5.0.0
+capstone
 xonsh
 plumbum
 pygnuutils


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'distutils'` on Python 3.12 or higher