### PR TITLE
client: set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`

### DIFF
--- a/src/rpcclient/rpcclient/darwin/client.py
+++ b/src/rpcclient/rpcclient/darwin/client.py
@@ -2,6 +2,7 @@ import ast
 import builtins
 import json
 import logging
+import os
 import plistlib
 import typing
 from collections import namedtuple
@@ -35,10 +36,13 @@ from rpcclient.darwin.syslog import Syslog
 from rpcclient.darwin.time import Time
 from rpcclient.darwin.xpc import Xpc
 from rpcclient.exceptions import CfSerializationError, GettingObjectiveCClassError, MissingLibraryError
-from rpcclient.protos.rpc_pb2 import CmdGetClassList, CmdShowClass, CmdShowObject
 from rpcclient.structs.consts import RTLD_GLOBAL, RTLD_NOW
 from rpcclient.symbol import Symbol
 from rpcclient.symbols_jar import SymbolsJar
+
+# make sure imports from the *_pb2 modules don't depend on the locally installed protobuf version
+os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
+from rpcclient.protos.rpc_pb2 import CmdGetClassList, CmdShowClass, CmdShowObject  # noqa: E402
 
 IsaMagic = namedtuple('IsaMagic', 'mask value')
 ISA_MAGICS = [


### PR DESCRIPTION
By default, the _pb2 module will try using the locally installed protobuf library which may be in conflict with the version being compiled. By setting this envvar to `python`, we force the protobuf python wrapper to parse the structs purely in python which is much slower, but will work cross workstations with different protobof libraries