### PR TITLE
shell: Fix shell startup

### DIFF
--- a/src/rpcclient/rpcclient/clients/ios/subsystems/accessibility.py
+++ b/src/rpcclient/rpcclient/clients/ios/subsystems/accessibility.py
@@ -320,7 +320,7 @@ class AXElement(AbstractSymbol, ClientBound["BaseIosClient[DarwinSymbolT_co]"], 
         await self.objc_call.z("longPress")
 
     @zyncio.zgeneratormethod
-    async def _iter(self) -> AsyncGenerator[Self]:
+    async def _iter(self) -> "AsyncGenerator[AXElement[DarwinSymbolT_co]]":
         current = await type(self).first_element(self)
         while current:
             yield current
@@ -329,7 +329,7 @@ class AXElement(AbstractSymbol, ClientBound["BaseIosClient[DarwinSymbolT_co]"], 
     def __iter__(self: "AXElement[DarwinSymbol]") -> "Iterator[AXElement[DarwinSymbol]]":
         return self._iter()
 
-    def __aiter__(self) -> "AsyncIterator[Self]":
+    def __aiter__(self) -> "AsyncIterator[AXElement[DarwinSymbolT_co]]":
         return self._iter.z()
 
     async def _element_for_attribute(self, axattribute: int, parameter: Any | None = None) -> Self | None:

--- a/src/rpcclient/rpcclient/core/client.py
+++ b/src/rpcclient/rpcclient/core/client.py
@@ -30,8 +30,6 @@ from typing_extensions import Buffer, Self, assert_never
 
 import zyncio
 from construct import Container
-from xonsh.built_ins import XSH
-from xonsh.main import main as xonsh_main
 
 from rpcclient.clients.darwin.consts import BLOCK_IS_GLOBAL
 from rpcclient.core.capture_fd import CaptureFD
@@ -610,22 +608,6 @@ class BaseCoreClient(Generic[SymbolT_co], zyncio.ZyncBase, abc.ABC):
         self.notifier.notify(ClientEvent.TERMINATED, self.id)
         self._bridge.close()
 
-    def shell(self) -> None:
-        self._logger.disabled = True
-
-        args = ["--rc"]
-        args.append(str((Path(__file__).parent / "xonshrc.py").absolute()))
-
-        XSH.ctx["_client_to_reuse"] = self
-
-        try:
-            logging.getLogger("parso.python.diff").disabled = True
-            logging.getLogger("parso.cache").disabled = True
-            logging.getLogger("asyncio").disabled = True
-            xonsh_main(args)
-        except SystemExit:
-            self._logger.disabled = False
-
     async def _execute(self, argv: list[str], envp: list[str], background=False) -> int:
         try:
             return (await self.rpc_call.z(MsgId.REQ_EXEC, background=background, argv=argv, envp=envp)).pid
@@ -756,6 +738,25 @@ class CoreClient(zyncio.SyncMixin, BaseCoreClient[SymbolT_co]):
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
+
+    def shell(self) -> None:
+        from xonsh.built_ins import XSH
+        from xonsh.main import main as xonsh_main
+
+        self._logger.disabled = True
+
+        args = ["--rc"]
+        args.append(str((Path(__file__).parent / "xonshrc.py").absolute()))
+
+        XSH.ctx["_client_to_reuse"] = self
+
+        try:
+            logging.getLogger("parso.python.diff").disabled = True
+            logging.getLogger("parso.cache").disabled = True
+            logging.getLogger("asyncio").disabled = True
+            xonsh_main(args)
+        except SystemExit:
+            self._logger.disabled = False
 
 
 class AsyncCoreClient(zyncio.AsyncMixin, BaseCoreClient[AsyncSymbolT_co]):

--- a/src/rpcclient/rpcclient/core/xonshrc.py
+++ b/src/rpcclient/rpcclient/core/xonshrc.py
@@ -25,7 +25,6 @@ from xonsh.cli_utils import Annotated, Arg, ArgParserAlias
 from xonsh.events import events
 from xonsh.tools import print_color
 
-from rpcclient.client_manager import ClientType
 from rpcclient.clients.ios.client import IosClient
 from rpcclient.clients.linux.client import LinuxClient
 from rpcclient.clients.macos.client import MacosClient
@@ -182,7 +181,7 @@ class RpcLsStub(LsStub):
 
 class XonshRc:
     def __init__(self):
-        self.client: ClientType = XSH.ctx.get("_client_to_reuse")
+        self.client: CoreClient = XSH.ctx.get("_client_to_reuse")
         self._commands = {}
         self._orig_aliases = {}
         self._orig_prompt = XSH.env["PROMPT"]


### PR DESCRIPTION
Broken by ZyncIO migration.

Fixed imports and moved `shell` method to `CoreClient` (from `BaseCoreClient`).