### PR TITLE
darwin: Add DarwinSymbol methods to ObjectiveCSymbol

### DIFF
--- a/src/rpcclient/rpcclient/clients/darwin/client.py
+++ b/src/rpcclient/rpcclient/clients/darwin/client.py
@@ -39,7 +39,6 @@ from rpcclient.clients.darwin.symbol import AsyncDarwinSymbol, BaseDarwinSymbol,
 from rpcclient.core.client import AsyncCoreClient, BaseCoreClient, CoreClient, RemoteCallArg
 from rpcclient.core.structs.consts import RTLD_GLOBAL, RTLD_NOW
 from rpcclient.core.subsystems.decorator import subsystem
-from rpcclient.core.symbol import BaseSymbol
 from rpcclient.core.symbols_jar import LazySymbol
 from rpcclient.exceptions import CfSerializationError, MissingLibraryError
 from rpcclient.protocol.rpc_bridge import AsyncRpcBridge, SyncRpcBridge
@@ -231,7 +230,7 @@ class BaseDarwinClient(BaseCoreClient[DarwinSymbolT_co]):
         return result
 
     @zyncio.zmethod
-    async def decode_cf(self, symbol: BaseSymbol) -> CfSerializable:
+    async def decode_cf(self, symbol: int) -> CfSerializable:
         if await self.symbols.CFGetTypeID.z(symbol) == self._CFNullTypeID:
             return None
 

--- a/src/rpcclient/rpcclient/clients/darwin/objective_c/objective_c_symbol.py
+++ b/src/rpcclient/rpcclient/clients/darwin/objective_c/objective_c_symbol.py
@@ -14,12 +14,11 @@ from rpcclient.clients.darwin._types import AsyncDarwinSymbolT_co, DarwinSymbolT
 from rpcclient.clients.darwin.objective_c import objc
 from rpcclient.clients.darwin.objective_c.objc import Method
 from rpcclient.clients.darwin.objective_c.objective_c_class import BoundObjectiveCMethod, Class
-from rpcclient.clients.darwin.symbol import BaseDarwinSymbol, DarwinSymbol
-from rpcclient.core._types import ClientBound
+from rpcclient.clients.darwin.symbol import AbstractDarwinSymbol, BaseDarwinSymbol, DarwinSymbol
 from rpcclient.core.client import RemoteCallArg
-from rpcclient.core.symbol import AbstractSymbol
 from rpcclient.core.symbols_jar import SymbolsJar
 from rpcclient.exceptions import RpcClientException
+from rpcclient.utils import readonly
 
 
 if TYPE_CHECKING:
@@ -40,7 +39,7 @@ class Ivar(Generic[DarwinSymbolT_co]):
     offset: int
 
 
-class ObjectiveCSymbol(AbstractSymbol, ClientBound["BaseDarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
+class ObjectiveCSymbol(AbstractDarwinSymbol, Generic[DarwinSymbolT_co]):
     """
     Wrapper object for an objective-c symbol.
     Allowing easier access to its properties, methods and ivars.
@@ -56,6 +55,9 @@ class ObjectiveCSymbol(AbstractSymbol, ClientBound["BaseDarwinClient[DarwinSymbo
         "properties",
     })
 
+    @readonly
+    def _client(self) -> "BaseDarwinClient[DarwinSymbolT_co]": ...
+
     def __init__(self, value: int, client: "BaseDarwinClient[DarwinSymbolT_co]") -> None:
         """
         Create an ObjectiveCSymbol object.
@@ -64,7 +66,7 @@ class ObjectiveCSymbol(AbstractSymbol, ClientBound["BaseDarwinClient[DarwinSymbo
         :return: ObjectiveCSymbol object.
         :rtype: ObjectiveCSymbol
         """
-        self._client = client
+        __class__._client.set(self, client)
         self._sym: DarwinSymbolT_co = client.symbol(value)
         self.ivars: list[Ivar[DarwinSymbolT_co]] = []
         self.methods: list[Method[DarwinSymbolT_co]] = []
@@ -73,6 +75,9 @@ class ObjectiveCSymbol(AbstractSymbol, ClientBound["BaseDarwinClient[DarwinSymbo
 
         if zyncio.is_sync(self):
             self.reload()
+
+    def __zync_delegate__(self) -> DarwinSymbolT_co:
+        return self._sym
 
     def _symbol_from_value(self, value: int) -> DarwinSymbolT_co:
         """

--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/location.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/location.py
@@ -43,7 +43,7 @@ class Location(ClientBound["BaseDarwinClient[DarwinSymbolT_co]"], Generic[Darwin
     @zyncio.zproperty
     async def _location_services_enabled(self) -> bool:
         """opt-in status for location services"""
-        return bool((await self._get_location_manager()).objc_call.z("locationServicesEnabled"))
+        return bool(await (await self._get_location_manager()).objc_call.z("locationServicesEnabled"))
 
     @_location_services_enabled.setter
     async def location_services_enabled(self, value: bool) -> None:

--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/processes.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/processes.py
@@ -880,7 +880,7 @@ class Process(ClientBound["BaseDarwinClient[DarwinSymbolT_co]"], Generic[DarwinS
 
     @zyncio.zproperty
     @cached_async_method
-    async def vmu_region_identifier(self: "Process[DarwinSymbolT_co]") -> DarwinSymbolT_co:
+    async def vmu_region_identifier(self) -> DarwinSymbolT_co:
         """Return the VMUVMRegionIdentifier object for this task."""
 
         VMUVMRegionIdentifier = await self._client.symbols.objc_getClass.z("VMUVMRegionIdentifier")

--- a/src/rpcclient/rpcclient/clients/darwin/symbol.py
+++ b/src/rpcclient/rpcclient/clients/darwin/symbol.py
@@ -6,7 +6,7 @@ from osstatus.cache import ErrorCode, get_possible_error_codes
 
 from rpcclient.clients.darwin.common import CfSerializable, CfSerializableAny, CfSerializableT
 from rpcclient.core.client import RemoteCallArg
-from rpcclient.core.symbol import AsyncSymbol, BaseSymbol, Symbol
+from rpcclient.core.symbol import AbstractSymbol, AsyncSymbol, BaseSymbol, Symbol
 from rpcclient.exceptions import UnrecognizedSelectorError
 from rpcclient.utils import assert_cast, readonly
 
@@ -17,12 +17,9 @@ if TYPE_CHECKING:
     from rpcclient.clients.darwin.subsystems.processes import Region
 
 
-class BaseDarwinSymbol(BaseSymbol):
+class AbstractDarwinSymbol(AbstractSymbol):
     @readonly
-    def _client(self) -> "BaseDarwinClient[Self]": ...
-
-    def __init__(self, value: int, client: "BaseDarwinClient[Self]") -> None:
-        super().__init__(value, client)
+    def _client(self) -> "BaseDarwinClient[BaseDarwinSymbol]": ...
 
     async def _objc_call(self, selector: str, *params, **kwargs) -> Any:
         """call an objc method on a given object"""
@@ -80,17 +77,25 @@ class BaseDarwinSymbol(BaseSymbol):
         return await self.get_cfdesc()
 
     @property
+    def osstatus(self) -> list[ErrorCode] | None:
+        """Get possible translation to given error code by querying osstatus"""
+        return get_possible_error_codes(self)
+
+
+class BaseDarwinSymbol(BaseSymbol, AbstractDarwinSymbol):
+    @readonly
+    def _client(self) -> "BaseDarwinClient[Self]": ...
+
+    def __init__(self, value: int, client: "BaseDarwinClient[Self]") -> None:
+        super().__init__(value, client)
+
+    @property
     def objc_symbol(self) -> "ObjectiveCSymbol[Self]":
         """
         Get an ObjectiveC symbol of the same address
         :return: Object representing the ObjectiveC symbol
         """
         return self._client.objc_symbol(self)
-
-    @property
-    def osstatus(self) -> list[ErrorCode] | None:
-        """Get possible translation to given error code by querying osstatus"""
-        return get_possible_error_codes(self)
 
     @property
     def stripped_value(self) -> Self:

--- a/src/rpcclient/rpcclient/core/subsystems/sysctl.py
+++ b/src/rpcclient/rpcclient/core/subsystems/sysctl.py
@@ -162,12 +162,12 @@ class Sysctl(ClientBound[ClientT_co]):
         return struct.unpack("<I", await self.get_by_name.z(name))[0]
 
     @zyncio.zmethod
-    async def set_int_by_name(self, name: str, value: int):
+    async def set_int_by_name(self, name: str, value: int) -> None:
         """equivalent of: sysctl <name> -w value"""
         await self.set_by_name.z(name, struct.pack("<I", value))
 
     @zyncio.zmethod
-    async def set_str_by_name(self, name: str, value: str):
+    async def set_str_by_name(self, name: str, value: str) -> None:
         """equivalent of: sysctl <name> -w value"""
         await self.set_by_name.z(name, value.encode() + b"\x00")
 


### PR DESCRIPTION
Fixes regression from migration to ZyncIO.

Extract shared functionality from `BaseDarwinSymbol` to `AbstractDarwinSymbol`, and use it as a mixin for both `BaseDarwinSymbol` and `ObjectiveCSymbol`.