### PR TITLE
client: prime progname/pid caches on every client creation

### DIFF
--- a/src/rpcclient/rpcclient/__main__.py
+++ b/src/rpcclient/rpcclient/__main__.py
@@ -31,9 +31,6 @@ def rpclocal(startup_files: tuple[str]) -> None:
 
     async def _connect() -> int:
         client = await manager.create(mode="local")
-        # Prime caches so the prompt can render progname/pid synchronously.
-        await client.get_progname()
-        await client.get_pid()
         return client.id
 
     cid = run_in_loop(_connect())
@@ -67,9 +64,6 @@ def rpcclient(
                     await client.rebind_symbols()
                 if load_all_libraries:
                     await client.load_all_libraries()
-            # Prime caches so the prompt can render progname/pid synchronously.
-            await client.get_progname()
-            await client.get_pid()
             return client.id
 
         cid = run_in_loop(_connect())

--- a/src/rpcclient/rpcclient/client_manager.py
+++ b/src/rpcclient/rpcclient/client_manager.py
@@ -66,6 +66,10 @@ class ClientManager:
             raise ValueError(f"Unknown client mode: {server_type}")
 
         client: ClientType = await client_factory.create(bridge=rpc_bridge)
+        # Prime caches so the prompt/repr can render progname/pid synchronously. Every creation
+        # path flows through here — CLI connect and interactive `mgr.create` alike.
+        await client.get_progname()
+        await client.get_pid()
         client.notifier.register(ClientEvent.TERMINATED, self._on_client_terminated)
         client.notifier.register(ClientEvent.CREATED, self._on_client_created)
         self.add(client, internal=internal)


### PR DESCRIPTION
## Problem

Clients created interactively from the console (`mgr.create(...)`) render with `?` placeholders in the prompt and repr:

```
Auto-switched to new client client ID: 77662
[osx| (77662) ?]: <MacosClient: ? | ?>
```

`_cached_progname`/`_cached_pid` are populated lazily on first `await`. The CLI connect entrypoints (`rpclocal`/`rpcclient`) primed them after connecting, but the interactive creation path went through `ClientManager.create` without priming.

## Fix

Prime the caches in `ClientManager.create` — the single choke point every creation path flows through (CLI connect *and* interactive `mgr.create`) — **before** the client is registered and the console auto-switches, so the prompt/repr render synchronously.

Removes the now-redundant priming from both `__main__.py` entrypoints (the cache check already made repeat calls no-ops).