### PR TITLE
fix(rpcclient): auto-resolve symbols in the IPython REPL

### DIFF
--- a/src/rpcclient/pyproject.toml
+++ b/src/rpcclient/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "requests",
     "protobuf",
     "inquirer3",
-    "ipython-smart-await>=0.2.0",
+    "ipython-smart-await>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/rpcclient/rpcclient/console/extensions/events.py
+++ b/src/rpcclient/rpcclient/console/extensions/events.py
@@ -7,6 +7,7 @@ from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from rpcclient.clients.darwin.objective_c import objective_c_class
 from rpcclient.core.symbols_jar import SymbolsJar
 from rpcclient.exceptions import GettingObjectiveCClassError, SymbolAbsentError
+from rpcclient.utils import run_in_loop
 
 
 class RpcEvents:
@@ -53,10 +54,13 @@ class RpcEvents:
             ):
                 continue
 
-            # 1) Generic: SymbolsJar lazy load
+            # 1) Generic: resolve the name to a real symbol. `get_lazy` performs the dlsym round-trip
+            # and raises SymbolAbsentError for unknown names (so they fall through to Obj-C autoload).
+            # Bind the resolved symbol — not a LazySymbol — since a bare name reference in the cell
+            # isn't rewritten by the `smart_await` transformer and so would never auto-resolve.
             if not hasattr(SymbolsJar, node.id):
                 try:
-                    symbol = getattr(client.symbols, node.id)
+                    symbol = run_in_loop(client.symbols.get_lazy(node.id))
                 except SymbolAbsentError:
                     pass
                 else:
@@ -66,11 +70,11 @@ class RpcEvents:
             # 2) Darwin-specific: Objective-C class autoload / lazy reload
             if hasattr(client, "objc_get_class"):
                 if objc_class_place_holder and existing is not None:
-                    existing.reload()
+                    run_in_loop(existing.reload())
                     continue
 
                 try:
-                    objc_cls = client.objc_get_class(node.id)
+                    objc_cls = run_in_loop(client.objc_get_class(node.id))
                 except GettingObjectiveCClassError:
                     pass
                 else:

--- a/src/rpcclient/rpcclient/core/symbols_jar.py
+++ b/src/rpcclient/rpcclient/core/symbols_jar.py
@@ -81,6 +81,11 @@ class LazySymbol(Generic[SymbolT_co]):
     def __repr__(self) -> str:
         return f"<{type(self).__name__} {self.name!r} of {self._client}>"
 
+    def __await__(self):
+        # Make the lazy handle a first-class awaitable so `await p.symbols.errno` yields the
+        # resolved symbol, and so the REPL (smart_await) auto-resolves it into a real symbol.
+        return self.resolve().__await__()
+
     async def resolve(self) -> SymbolT_co:
         return await self._client.symbols.get_lazy(self.name)
 

--- a/src/rpcclient/tests/test_client.py
+++ b/src/rpcclient/tests/test_client.py
@@ -5,6 +5,8 @@ import pytest
 from rpcclient.clients.darwin.client import DarwinClient
 from rpcclient.core.client import RemoteCallArg
 from rpcclient.core.subsystems.decorator import SubsystemNotAvailable, subsystem
+from rpcclient.core.symbol import Symbol
+from rpcclient.core.symbols_jar import LazySymbol
 from rpcclient.exceptions import ArgumentError
 from tests._types import Client
 
@@ -16,6 +18,24 @@ def _get_subsystems(client) -> list[str]:
             if isinstance(attr, subsystem):
                 names.add(name)
     return sorted(names)
+
+
+async def test_uncached_symbol_is_lazy(client: Client) -> None:
+    # An unresolved symbol name yields a LazySymbol placeholder (sync attribute access can't await).
+    if "strlen" in client.symbols:
+        del client.symbols["strlen"]
+    assert isinstance(client.symbols.strlen, LazySymbol)
+
+
+async def test_lazy_symbol_is_awaitable(client: Client) -> None:
+    # `await`-ing an unresolved lazy handle resolves it to a real Symbol (what the REPL relies on).
+    if "strlen" in client.symbols:
+        del client.symbols["strlen"]
+    lazy = client.symbols.strlen
+    assert isinstance(lazy, LazySymbol)
+    resolved = await lazy
+    assert isinstance(resolved, Symbol)
+    assert int(resolved) == int(await lazy.resolve())
 
 
 async def test_peek(client: Client) -> None:


### PR DESCRIPTION
## Problem

In the console, typing `p.symbols.errno` (or a bare `errno`) surfaced an unresolved placeholder instead of a real symbol:

```
[osx| ...]: p.symbols.errno
[osx| ...]: <LazySymbol 'errno' of <MacosClient: ...>>
```

Resolving a symbol requires an async `dlsym` round-trip, and the synchronous accessors (`__getattr__`/`__getitem__`) can't `await`, so they return a `LazySymbol` placeholder.

## Fix

- **`LazySymbol.__await__`** — makes the lazy handle a first-class awaitable, so `await p.symbols.errno` yields the resolved symbol and the REPL's `smart_await` transformer auto-resolves it on attribute/subscript access.
- **console events (`pre_run_cell`)** — inject a *resolved* symbol (via `get_lazy`) for bare names instead of a `LazySymbol`. A bare `Name` is never rewritten by `smart_await`, so it would otherwise stay lazy. Unknown names now correctly raise `SymbolAbsentError` and fall through to the Obj-C class autoload — whose async `objc_get_class`/`reload` calls are now actually awaited (previously fire-and-forget coroutines that emitted "coroutine was never awaited" warnings).
- **dependency** — bump `ipython-smart-await>=0.3.0`, which broadens the REPL auto-await from coroutines to any awaitable (adds `__await__` support).

The programmatic API is unchanged: `symbols.X` still returns a `LazySymbol` outside the REPL and remains valid as a deferred remote-call arg (`isinstance(arg, LazySymbol)`).

## Tests

- `test_uncached_symbol_is_lazy` — unresolved name yields a `LazySymbol`.
- `test_lazy_symbol_is_awaitable` — `await`-ing it resolves to a real `Symbol`.

Verified end-to-end against a live server driving the real `smart_await` transformer: `p.symbols.errno` and bare `errno` both resolve to `DarwinSymbol`; unknown names don't bind and no "never awaited" warnings; valid Obj-C class names still autoload.

Depends on `ipython-smart-await` 0.3.0 (published to PyPI).