### PR TITLE
fix(rpcclient): make cfdesc work on XPC objects

### DIFF
--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/xpc.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/xpc.py
@@ -7,8 +7,8 @@ from construct import Container
 from rpcclient.clients.darwin._types import DarwinSymbolT_co
 from rpcclient.clients.darwin.common import CfSerializable
 from rpcclient.clients.darwin.consts import XPC_ARRAY_APPEND
+from rpcclient.clients.darwin.symbol import AbstractDarwinSymbol
 from rpcclient.core._types import ClientBound
-from rpcclient.core.symbol import AbstractSymbol
 from rpcclient.exceptions import BadReturnValueError, RpcXpcSerializationError
 
 
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
     from rpcclient.clients.darwin.client import DarwinClient
 
 
-class XPCObject(AbstractSymbol, ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
+class XPCObject(AbstractDarwinSymbol, ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
     def __init__(self, value: int, client: "DarwinClient[DarwinSymbolT_co]") -> None:
-        self._client = client
+        AbstractDarwinSymbol._client.set(self, client)
         self._sym: DarwinSymbolT_co = client.symbol(value)
 
     def _symbol_from_value(self, value: int) -> DarwinSymbolT_co:

--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/xpc.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/xpc.py
@@ -10,15 +10,19 @@ from rpcclient.clients.darwin.consts import XPC_ARRAY_APPEND
 from rpcclient.clients.darwin.symbol import AbstractDarwinSymbol
 from rpcclient.core._types import ClientBound
 from rpcclient.exceptions import BadReturnValueError, RpcXpcSerializationError
+from rpcclient.utils import readonly
 
 
 if TYPE_CHECKING:
     from rpcclient.clients.darwin.client import DarwinClient
 
 
-class XPCObject(AbstractDarwinSymbol, ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
+class XPCObject(AbstractDarwinSymbol, Generic[DarwinSymbolT_co]):
+    @readonly
+    def _client(self) -> "DarwinClient[DarwinSymbolT_co]": ...
+
     def __init__(self, value: int, client: "DarwinClient[DarwinSymbolT_co]") -> None:
-        AbstractDarwinSymbol._client.set(self, client)
+        XPCObject._client.set(self, client)
         self._sym: DarwinSymbolT_co = client.symbol(value)
 
     def _symbol_from_value(self, value: int) -> DarwinSymbolT_co:


### PR DESCRIPTION
## Problem

`cfdesc` (and `py`, `objc_call`, `osstatus`) raised `AttributeError` on XPC objects:

```
a = p.xpc.create_xpc_dictionary()
a.cfdesc
# AttributeError: 'XPCDictionary' object has no attribute 'cfdesc'
```

## Cause

These conveniences live on `AbstractDarwinSymbol`, but `XPCObject` extended the generic `AbstractSymbol`, so XPC objects never inherited them.

## Fix

Reparent `XPCObject` onto `AbstractDarwinSymbol`. It's already an `AbstractSymbol` subclass, so existing behavior is preserved while XPC objects now expose the same interface as any other Darwin symbol. `AbstractDarwinSymbol._client` is a read-only descriptor, so `__init__` sets it via `.set()` (the same pattern `Symbol.__init__` uses).