### PR TITLE
preferences: default cf hostname to AnyHost + add managed (MDM) subsystem

### DIFF
--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/cfpreferences.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/cfpreferences.py
@@ -27,7 +27,7 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         self._client = client
 
     async def get_keys(
-        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesCurrentHost
+        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesAnyHost
     ) -> list[str]:
         """wrapper for CFPreferencesCopyKeyList"""
         keys = await (
@@ -49,7 +49,7 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         key: str,
         application_id: str,
         username: str = kCFPreferencesCurrentUser,
-        hostname: str = kCFPreferencesCurrentHost,
+        hostname: str = kCFPreferencesAnyHost,
         typ: type[CfSerializableT] | tuple[type[CfSerializableT], ...] = CfSerializableAny,
     ) -> CfSerializableT:
         """wrapper for CFPreferencesCopyValue"""
@@ -65,7 +65,7 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         return value
 
     async def get_dict(
-        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesCurrentHost
+        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesAnyHost
     ) -> dict:
         """get a dictionary representation of given preference"""
         key_list = await self.get_keys(application_id, username, hostname)
@@ -80,7 +80,7 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         value: CfSerializable,
         application_id: str,
         username: str = kCFPreferencesCurrentUser,
-        hostname: str = kCFPreferencesCurrentHost,
+        hostname: str = kCFPreferencesAnyHost,
     ):
         """wrapper for CFPreferencesSetValue"""
         await self._client.symbols.CFPreferencesSetValue(
@@ -96,7 +96,7 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         key: str,
         application_id: str,
         username: str = kCFPreferencesCurrentUser,
-        hostname: str = kCFPreferencesCurrentHost,
+        hostname: str = kCFPreferencesAnyHost,
     ):
         """remove a given key from a preference"""
         await self._client.symbols.CFPreferencesSetValue(
@@ -112,7 +112,7 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         d: dict,
         application_id: str,
         username: str = kCFPreferencesCurrentUser,
-        hostname: str = kCFPreferencesCurrentHost,
+        hostname: str = kCFPreferencesAnyHost,
     ):
         """set entire preference dictionary (erase first if exists)"""
         with suppress(NoSuchPreferenceError):
@@ -124,21 +124,21 @@ class CFPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[Darwi
         d: dict,
         application_id: str,
         username: str = kCFPreferencesCurrentUser,
-        hostname: str = kCFPreferencesCurrentHost,
+        hostname: str = kCFPreferencesAnyHost,
     ):
         """update preference dictionary"""
         for k, v in d.items():
             await self.set(k, v, application_id, username, hostname)
 
     async def clear(
-        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesCurrentHost
+        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesAnyHost
     ):
         """remove all values from given preference"""
         for k in await self.get_keys(application_id, username, hostname):
             await self.remove(k, application_id, username, hostname)
 
     async def sync(
-        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesCurrentHost
+        self, application_id: str, username: str = kCFPreferencesCurrentUser, hostname: str = kCFPreferencesAnyHost
     ):
         if not await self._client.symbols.CFPreferencesSynchronize(
             await self._client.cf(application_id),

--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/process_preferences.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/process_preferences.py
@@ -1,0 +1,149 @@
+from typing import TYPE_CHECKING, Generic
+
+from rpcclient.clients.darwin._types import DarwinSymbolT_co
+from rpcclient.clients.darwin.common import CfSerializable
+from rpcclient.clients.darwin.subsystems.cfpreferences import (
+    kCFPreferencesAnyHost,
+    kCFPreferencesAnyUser,
+    kCFPreferencesCurrentUser,
+)
+from rpcclient.core._types import ClientBound
+
+
+if TYPE_CHECKING:
+    from rpcclient.clients.darwin.client import DarwinClient  # noqa: F401  (used in string annotation)
+    from rpcclient.clients.darwin.subsystems.processes import Process
+
+
+class ProcessPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
+    """
+    Read/write a preference domain the way a *specific* process resolves it.
+
+    With no ``application_id`` this targets the process's OWN bundle-identifier domain - i.e. what
+    ``[NSUserDefaults standardUserDefaults]`` reads/writes for that process. (Note it is NOT
+    ``kCFPreferencesCurrentApplication``: "current application" would be rpcserver, not the target.)
+
+    Preference location is process-relative (container, uid), so a plain ``CFPreferencesCopyValue``
+    from rpcserver would resolve in *rpcserver's* context. Instead this uses the container-scoped CF
+    SPI - ``_CFPreferencesCopyValueWithContainer`` / ``_CFPreferencesSetValueWithContainer`` /
+    ``_CFPreferencesCopyMultipleWithContainer`` - passing the *target's* container as a CFString path, so the
+    request still goes through cfprefsd (correct merged/managed view, cache-coherent writes) but is
+    resolved against the target's home.
+
+    The container is the target's ``CFFIXED_USER_HOME`` (its data container) when it has one, else its
+    uid's home (``/var/root`` for uid 0, otherwise ``/var/mobile``) - so a bare-domain daemon resolves
+    correctly too. cfprefsd handles own/foreign/group resolution from there. iOS path layout.
+    """
+
+    def __init__(
+        self, process: "Process[DarwinSymbolT_co]", application_id: str | None = None, *, any_user: bool = False
+    ) -> None:
+        self._client = process._client
+        self._process = process
+        self._id = application_id  # None -> resolved lazily to the process's own bundle id
+        self._user = kCFPreferencesAnyUser if any_user else kCFPreferencesCurrentUser
+        self._host = kCFPreferencesAnyHost
+
+    async def application_id(self) -> str:
+        """the resolved domain: the explicit id, or the process's own bundle id (``standardUserDefaults``)"""
+        if self._id is None:
+            self._id = await type(self._process).bundle_id(self._process) or await type(self._process).name(
+                self._process
+            )
+        return self._id
+
+    async def container(self) -> str:
+        """the base directory the target resolves CurrentUser domains against.
+
+        The target's data container (``CFFIXED_USER_HOME``) if sandboxed, else its ``HOME``
+        (correct on macOS and iOS alike); falls back to the uid's iOS home if it has neither.
+        """
+        env = await type(self._process).environ(self._process)
+        home = env.get("CFFIXED_USER_HOME") or env.get("HOME")
+        if home:
+            return home
+        return "/var/root" if await type(self._process).uid(self._process) == 0 else "/var/mobile"
+
+    async def _container_arg(self):
+        # the *WithContainer SPI take the container as a CFString path (NOT a CFURL - a CFURL crashes)
+        return await self._client.cf(await self.container())
+
+    async def path(self) -> str:
+        """the fully-resolved plist file this domain maps to for the target (CurrentUser / AnyHost)"""
+        base = (
+            "/Library/Preferences"
+            if self._user == kCFPreferencesAnyUser
+            else f"{await self.container()}/Library/Preferences"
+        )
+        return f"{base}/{await self.application_id()}.plist"
+
+    async def get(self, key: str) -> CfSerializable:
+        """read a single key as the target resolves it (``_CFPreferencesCopyValueWithContainer``)"""
+        return await (
+            await self._client.symbols._CFPreferencesCopyValueWithContainer(
+                await self._client.cf(key),
+                await self._client.cf(await self.application_id()),
+                await self._client.cf(self._user),
+                await self._client.cf(self._host),
+                await self._container_arg(),
+            )
+        ).py()
+
+    async def get_dict(self) -> dict:
+        """the whole domain as the target resolves it (key list, then a value per key)"""
+        # NOTE: don't use _CFPreferencesCopyMultipleWithContainer with keysToFetch=NULL - unlike the
+        # public CopyMultiple it does not guard the NULL and crashes. Enumerate keys, then read each.
+        return {key: await self.get(key) for key in await self.get_keys()}
+
+    async def get_keys(self) -> list[str]:
+        result = await self._client.symbols._CFPreferencesCopyKeyListWithContainer(
+            await self._client.cf(await self.application_id()),
+            await self._client.cf(self._user),
+            await self._client.cf(self._host),
+            await self._container_arg(),
+        )
+        if not result:
+            return []
+        return await result.py(list)
+
+    async def set(self, key: str, value: CfSerializable) -> None:
+        """set a single key (value=None removes), then sync"""
+        container = await self._container_arg()
+        await self._set_value(key, value, container)
+        await self._sync(container)
+
+    async def remove(self, key: str) -> None:
+        await self.set(key, None)
+
+    async def set_dict(self, d: dict) -> None:
+        """replace the whole domain (removes keys not present in ``d``), then sync"""
+        existing = set(await self.get_keys())
+        container = await self._container_arg()
+        for key in existing - set(d):
+            await self._set_value(key, None, container)
+        for key, value in d.items():
+            await self._set_value(key, value, container)
+        await self._sync(container)
+
+    async def clear(self) -> None:
+        await self.set_dict({})
+
+    async def _set_value(self, key: str, value: CfSerializable, container) -> None:
+        # value=None must be a NULL pointer to REMOVE the key; client.cf(None) is kCFNull, not NULL
+        cf_value = 0 if value is None else await self._client.cf(value)
+        await self._client.symbols._CFPreferencesSetValueWithContainer(
+            await self._client.cf(key),
+            cf_value,
+            await self._client.cf(await self.application_id()),
+            await self._client.cf(self._user),
+            await self._client.cf(self._host),
+            container,
+        )
+
+    async def _sync(self, container) -> None:
+        await self._client.symbols._CFPreferencesSynchronizeWithContainer(
+            await self._client.cf(await self.application_id()),
+            await self._client.cf(self._user),
+            await self._client.cf(self._host),
+            container,
+        )

--- a/src/rpcclient/rpcclient/clients/darwin/subsystems/processes.py
+++ b/src/rpcclient/rpcclient/clients/darwin/subsystems/processes.py
@@ -77,6 +77,7 @@ from rpcclient.clients.darwin.structs import (
     vnode_fdinfowithpath,
     x86_thread_state64_t,
 )
+from rpcclient.clients.darwin.subsystems.process_preferences import ProcessPreferences
 from rpcclient.clients.darwin.symbol import DarwinSymbol
 from rpcclient.core._types import ClientBound
 from rpcclient.core.structs.consts import SEEK_SET, SIGKILL, SIGTERM
@@ -110,6 +111,7 @@ logger = logging.getLogger(__name__)
 CDHASH_SIZE = 20
 CHUNK_SIZE = 1024 * 64
 APP_SUFFIX = ".app/"
+CS_OPS_IDENTITY = 11  # csops(2) op: copy the code-signing identity string
 
 
 @dataclasses.dataclass
@@ -907,6 +909,21 @@ class Process(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbo
         """Return the process name from task info."""
         return (await self._get_pbsd()).pbi_name
 
+    async def bundle_id(self) -> str | None:
+        """Return the process's code-signing identity via ``csops(CS_OPS_IDENTITY)``.
+
+        For a signed app or daemon this is its bundle identifier (e.g. ``com.apple.CrashReporter``) -
+        the domain its ``NSUserDefaults standardUserDefaults`` uses. None if the process is unsigned
+        or has no identity. Works for daemons too, unlike ``SBSCopyDisplayIdentifierForProcessID``.
+        """
+        size = 1024
+        async with self._client.safe_malloc(size) as buf:
+            if await self._client.symbols.csops(self.pid, CS_OPS_IDENTITY, buf, size):
+                return None
+            # blob layout: uint32 type, uint32 length (big-endian), then the identity C-string
+            identity = (await buf.peek(size))[8:].split(b"\x00", 1)[0]
+        return identity.decode() if identity else None
+
     async def ppid(self) -> int:
         """Return the parent process id."""
         return (await self._get_pbsd()).pbi_ppid
@@ -945,9 +962,10 @@ class Process(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbo
         """Return a Process wrapper for the parent pid."""
         return type(self)(self._client, await type(self).ppid(self))
 
-    async def environ(self) -> list[str]:
-        """Return the process environment variables."""
-        return await (await (await type(self).vmu_proc_info(self)).objc_call("envVars")).py(list)
+    async def environ(self) -> dict[str, str]:
+        """Return the process environment as a ``KEY -> VALUE`` mapping."""
+        entries = await (await (await type(self).vmu_proc_info(self)).objc_call("envVars")).py(list)
+        return dict(entry.partition("=")[::2] for entry in entries)
 
     async def arguments(self) -> list[str]:
         """Return the process argument list."""
@@ -960,6 +978,16 @@ class Process(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbo
     async def procargs2(self) -> Container:
         """Parse and return the PROCARGS2 buffer."""
         return procargs2_t.parse(await type(self).raw_procargs2(self))
+
+    def preferences(
+        self, application_id: str | None = None, *, any_user: bool = False
+    ) -> "ProcessPreferences[DarwinSymbolT_co]":
+        """Read/write a preference domain as *this* process resolves it (container, uid).
+
+        With no ``application_id`` this is the process's own bundle-id domain - the
+        ``standardUserDefaults`` domain. See ``ProcessPreferences``.
+        """
+        return ProcessPreferences(self, application_id, any_user=any_user)
 
     async def get_regions(self) -> list[Region[DarwinSymbolT_co]]:
         """Return the list of VM regions for the process."""

--- a/src/rpcclient/rpcclient/clients/ios/client.py
+++ b/src/rpcclient/rpcclient/clients/ios/client.py
@@ -7,6 +7,7 @@ from rpcclient.clients.ios.subsystems.backlight import Backlight
 from rpcclient.clients.ios.subsystems.installations import Installations
 from rpcclient.clients.ios.subsystems.lockdown import Lockdown
 from rpcclient.clients.ios.subsystems.mobile_gestalt import MobileGestalt
+from rpcclient.clients.ios.subsystems.preferences import IosPreferences
 from rpcclient.clients.ios.subsystems.processes import IosProcesses
 from rpcclient.clients.ios.subsystems.screen_capture import ScreenCapture
 from rpcclient.clients.ios.subsystems.springboard import SpringBoard
@@ -34,6 +35,10 @@ class IosClient(DarwinClient[DarwinSymbolT_co]):
     @subsystem
     def processes(self) -> IosProcesses[DarwinSymbolT_co]:
         return IosProcesses(self)
+
+    @subsystem
+    def preferences(self) -> IosPreferences[DarwinSymbolT_co]:
+        return IosPreferences(self)
 
     @subsystem
     def lockdown(self) -> Lockdown[DarwinSymbolT_co]:

--- a/src/rpcclient/rpcclient/clients/ios/subsystems/managed_preferences.py
+++ b/src/rpcclient/rpcclient/clients/ios/subsystems/managed_preferences.py
@@ -1,0 +1,315 @@
+import plistlib
+import uuid
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Generic
+
+from rpcclient.clients.darwin._types import DarwinSymbolT_co
+from rpcclient.clients.darwin.common import CfSerializable
+from rpcclient.clients.darwin.consts import kCFAllocatorDefault
+from rpcclient.core._types import ClientBound
+from rpcclient.exceptions import BadReturnValueError, RpcClientException, RpcFileNotFoundError
+
+
+if TYPE_CHECKING:
+    from rpcclient.clients.darwin.client import DarwinClient
+
+MANAGED_PREFERENCES_ROOT = "/Library/Managed Preferences"
+DEFAULT_PROFILE_PREFIX = "com.rpcclient.managed"
+MCX_PAYLOAD_TYPE = "com.apple.ManagedClient.preferences"
+RESTRICTIONS_PAYLOAD_TYPE = "com.apple.applicationaccess"
+
+
+class _MCBase(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
+    """shared MCProfileConnection plumbing (iOS ManagedConfiguration)"""
+
+    def __init__(self, client: "DarwinClient[DarwinSymbolT_co]") -> None:
+        self._client = client
+
+    async def _shared_connection(self):
+        await self._client.load_framework("ManagedConfiguration")
+        cls = await self._client.symbols.objc_getClass("MCProfileConnection")
+        if not cls:
+            raise RpcClientException("MCProfileConnection is unavailable (ManagedConfiguration failed to load)")
+        return await cls.objc_call("sharedConnection")
+
+    async def _raise_on_mc_error(self, p_error, what: str) -> None:
+        err = await p_error.getindex(0)
+        if not err:
+            return
+        reason = await (await self._client.objc_symbol(err).objc_call("localizedDescription")).py()
+        raise BadReturnValueError(f"{what} failed: {reason}")
+
+
+class ManagedProfile(_MCBase[DarwinSymbolT_co], Generic[DarwinSymbolT_co]):
+    """
+    The MDM Managed Preferences store (``com.apple.ManagedClient.preferences``), plus the raw
+    configuration-profile primitives that deliver it.
+
+    Reads of the *effective* value come off the plists under
+    ``/Library/Managed Preferences[/<user>]/<application_id>.plist``. Writes install/remove a
+    profile through profiled (``-[MCProfileConnection installProfileData:outError:]`` /
+    ``removeProfileWithIdentifier:``) - the store is never poked directly.
+    """
+
+    def __init__(self, client: "DarwinClient[DarwinSymbolT_co]", user: str = "mobile") -> None:
+        super().__init__(client)
+        self._user = user
+
+    # -- managed preferences (per-domain) ------------------------------------
+
+    def path(self, application_id: str) -> str:
+        """absolute path of the effective managed plist backing a given domain"""
+        root = MANAGED_PREFERENCES_ROOT
+        if self._user:
+            root = f"{root}/{self._user}"
+        return f"{root}/{application_id}.plist"
+
+    def default_identifier(self, application_id: str) -> str:
+        """the profile identifier ``set`` / ``set_dict`` use for a given domain"""
+        return f"{DEFAULT_PROFILE_PREFIX}.{application_id}"
+
+    async def get_dict(self, application_id: str) -> dict:
+        """read the effective managed domain (empty dict if nothing is managed)"""
+        try:
+            buf = await self._client.fs.read_file(self.path(application_id))
+        except RpcFileNotFoundError:
+            return {}
+        return plistlib.loads(buf) if buf else {}
+
+    async def get_keys(self, application_id: str) -> list[str]:
+        """list the managed keys of a given domain"""
+        return list((await self.get_dict(application_id)).keys())
+
+    async def get_value(self, key: str, application_id: str) -> CfSerializable:
+        """read a single managed value (None if the key isn't managed)"""
+        return (await self.get_dict(application_id)).get(key)
+
+    async def set(self, key: str, value: CfSerializable, application_id: str, *, identifier: str | None = None) -> str:
+        """force a single managed value (merged over the current view). returns the profile identifier"""
+        forced = await self.get_dict(application_id)
+        forced[key] = value
+        return await self.set_dict(forced, application_id, identifier=identifier)
+
+    async def set_dict(self, d: Mapping, application_id: str, *, identifier: str | None = None) -> str:
+        """force an entire managed domain by installing an MCX profile. returns the profile identifier"""
+        identifier = identifier or self.default_identifier(application_id)
+        profile = self._build_mcx_profile(application_id, dict(d), identifier)
+        await self.install(plistlib.dumps(profile, fmt=plistlib.FMT_XML))
+        return identifier
+
+    async def clear(self, application_id: str, *, identifier: str | None = None) -> None:
+        """remove the managed profile backing a domain"""
+        await self.remove(identifier or self.default_identifier(application_id))
+
+    # -- raw configuration profiles ------------------------------------------
+
+    async def install(self, profile_data: bytes) -> None:
+        """install a full configuration profile via ``-[MCProfileConnection installProfileData:outError:]``"""
+        connection = await self._shared_connection()
+        data = await self._client.symbols.CFDataCreate(kCFAllocatorDefault, profile_data, len(profile_data))
+        async with self._client.safe_malloc(8) as p_error:
+            await p_error.setindex(0, 0)
+            await connection.objc_call("installProfileData:outError:", data, p_error)
+            await self._raise_on_mc_error(p_error, "installProfileData")
+
+    async def remove(self, identifier: str) -> None:
+        """remove an installed profile via ``-[MCProfileConnection removeProfileWithIdentifier:]``"""
+        connection = await self._shared_connection()
+        await connection.objc_call("removeProfileWithIdentifier:", await self._client.cf(identifier))
+
+    async def is_installed(self, identifier: str) -> bool:
+        """query ``-[MCProfileConnection isProfileInstalledWithIdentifier:outError:]``"""
+        connection = await self._shared_connection()
+        async with self._client.safe_malloc(8) as p_error:
+            await p_error.setindex(0, 0)
+            result = await connection.objc_call(
+                "isProfileInstalledWithIdentifier:outError:", await self._client.cf(identifier), p_error
+            )
+            await self._raise_on_mc_error(p_error, "isProfileInstalledWithIdentifier")
+        return bool(result)
+
+    async def get_data(self, identifier: str) -> bytes | None:
+        """raw plist of an installed profile (``-[MCProfileConnection installedProfileDataWithIdentifier:]``)"""
+        connection = await self._shared_connection()
+        data = await connection.objc_call("installedProfileDataWithIdentifier:", await self._client.cf(identifier))
+        if not data:
+            return None
+        length = await data.objc_call("length")
+        if not length:
+            return b""
+        return await (await data.objc_call("bytes")).peek(length)
+
+    async def get(self, identifier: str) -> dict | None:
+        """read back an installed profile through profiled and parse it (None if absent).
+
+        Returns what the profile *declares* - not the effective merged value (that is ``get_dict``).
+        Signed profiles are CMS-wrapped and won't parse.
+        """
+        data = await self.get_data(identifier)
+        if not data:
+            return None
+        return plistlib.loads(data)
+
+    def _build_mcx_profile(self, application_id: str, settings: dict, identifier: str) -> dict:
+        return {
+            "PayloadType": "Configuration",
+            "PayloadVersion": 1,
+            "PayloadIdentifier": identifier,
+            "PayloadUUID": str(uuid.uuid4()).upper(),
+            "PayloadDisplayName": f"Managed {application_id}",
+            "PayloadContent": [
+                {
+                    "PayloadType": MCX_PAYLOAD_TYPE,
+                    "PayloadVersion": 1,
+                    "PayloadIdentifier": f"{identifier}.{application_id}",
+                    "PayloadUUID": str(uuid.uuid4()).upper(),
+                    "PayloadContent": {
+                        application_id: {"Forced": [{"mcx_preference_settings": settings}]},
+                    },
+                }
+            ],
+        }
+
+
+class ManagedRestrictions(_MCBase[DarwinSymbolT_co], Generic[DarwinSymbolT_co]):
+    """
+    MDM restrictions / MCFeature settings (the ``com.apple.applicationaccess`` namespace).
+
+    These are NOT plist keys: the effective value is a merge of the built-in default and the
+    restrictions contributed by installed profiles/clients. This is the store behind accessors
+    like ``DiagnosticLogSubmissionEnabled()`` (``allowDiagnosticSubmission``).
+
+    Set them either directly through ``MCProfileConnection`` (``set_bool`` / ``set_parameters``)
+    or by installing a Restrictions profile (``install`` / ``remove``).
+    """
+
+    async def effective_bool(self, setting: str) -> bool:
+        """``-[MCProfileConnection effectiveBoolValueForSetting:]`` (merged default + restrictions)"""
+        connection = await self._shared_connection()
+        return bool(await connection.objc_call("effectiveBoolValueForSetting:", await self._client.cf(setting)))
+
+    async def default_bool(self, setting: str) -> bool:
+        """built-in default (``-[MCProfileConnection defaultBoolValueForSetting:]``)"""
+        connection = await self._shared_connection()
+        return bool(await connection.objc_call("defaultBoolValueForSetting:", await self._client.cf(setting)))
+
+    async def effective_value(self, setting: str) -> CfSerializable:
+        """``-[MCProfileConnection effectiveValueForSetting:]`` for non-boolean settings"""
+        connection = await self._shared_connection()
+        result = await connection.objc_call("effectiveValueForSetting:", await self._client.cf(setting))
+        if not result:
+            return None
+        return await result.py()
+
+    async def effective_parameters(self, setting: str) -> dict | None:
+        """the effective parameters dict (``-[MCProfileConnection effectiveParametersForBoolSetting:]``).
+
+        Use this to discover the parameters shape, tweak it, and hand it back to ``set_parameters``.
+        """
+        connection = await self._shared_connection()
+        result = await connection.objc_call("effectiveParametersForBoolSetting:", await self._client.cf(setting))
+        if not result:
+            return None
+        return await result.py(dict)
+
+    async def default_parameters(self, setting: str) -> dict | None:
+        """the built-in default parameters dict (``-[MCProfileConnection defaultParametersForBoolSetting:]``)"""
+        connection = await self._shared_connection()
+        result = await connection.objc_call("defaultParametersForBoolSetting:", await self._client.cf(setting))
+        if not result:
+            return None
+        return await result.py(dict)
+
+    async def effective_restrictions(self) -> dict:
+        """the whole effective restrictions map - every setting at once
+        (``-[MCProfileConnection effectiveRestrictions]``).
+
+        This is the bulk view (setting -> value); ``effective_parameters(setting)`` is the
+        per-setting metadata for one key. There is no bulk-default equivalent - defaults are
+        exposed per-setting only (``default_bool`` / ``default_parameters``).
+        """
+        connection = await self._shared_connection()
+        result = await connection.objc_call("effectiveRestrictions")
+        if not result:
+            return {}
+        return await result.py(dict)
+
+    async def user_restrictions(self) -> dict:
+        """the whole user-set restrictions map (``-[MCProfileConnection userSettings]``)"""
+        connection = await self._shared_connection()
+        result = await connection.objc_call("userSettings")
+        if not result:
+            return {}
+        return await result.py(dict)
+
+    async def set_bool(self, setting: str, value: bool) -> None:
+        """set a boolean restriction directly (``-[MCProfileConnection setBoolValue:forSetting:]``).
+
+        No profile install. Protected settings may need the richer
+        ``setBoolValue:ask:forSetting:configurationUUID:toSystem:user:credentialSet:`` variants,
+        which are not wrapped here.
+        """
+        connection = await self._shared_connection()
+        await connection.objc_call("setBoolValue:forSetting:", value, await self._client.cf(setting))
+
+    async def set_parameters(self, setting: str, parameters: Mapping, *, value_setting: bool = False) -> None:
+        """set a restriction's full parameters (``-[MCProfileConnection setParameters:for{Bool,Value}Setting:]``).
+
+        ``parameters`` is the same dict shape returned by ``default_parameters`` /
+        ``effective_parameters`` - fetch one, modify it, pass it back.
+        """
+        selector = "setParameters:forValueSetting:" if value_setting else "setParameters:forBoolSetting:"
+        connection = await self._shared_connection()
+        await connection.objc_call(selector, await self._client.cf(dict(parameters)), await self._client.cf(setting))
+
+    async def install(self, restrictions: Mapping, *, identifier: str | None = None) -> str:
+        """impose restrictions by installing a ``com.apple.applicationaccess`` profile. returns the identifier.
+
+        ``restrictions`` maps restriction keys to values, e.g. ``{"allowDiagnosticSubmission": False}``.
+        Reinstalling the same ``identifier`` replaces the set; remove with ``remove``.
+        """
+        identifier = identifier or f"{DEFAULT_PROFILE_PREFIX}.restrictions"
+        profile = self._build_restrictions_profile(dict(restrictions), identifier)
+        await ManagedProfile(self._client).install(plistlib.dumps(profile, fmt=plistlib.FMT_XML))
+        return identifier
+
+    async def remove(self, *, identifier: str | None = None) -> None:
+        """remove the restrictions profile installed by ``install``"""
+        await ManagedProfile(self._client).remove(identifier or f"{DEFAULT_PROFILE_PREFIX}.restrictions")
+
+    def _build_restrictions_profile(self, restrictions: dict, identifier: str) -> dict:
+        return {
+            "PayloadType": "Configuration",
+            "PayloadVersion": 1,
+            "PayloadIdentifier": identifier,
+            "PayloadUUID": str(uuid.uuid4()).upper(),
+            "PayloadDisplayName": "Restrictions",
+            "PayloadContent": [
+                {
+                    "PayloadType": RESTRICTIONS_PAYLOAD_TYPE,
+                    "PayloadVersion": 1,
+                    "PayloadIdentifier": f"{identifier}.applicationaccess",
+                    "PayloadUUID": str(uuid.uuid4()).upper(),
+                    # Restrictions keys live directly in the payload dict (not wrapped in Forced)
+                    **restrictions,
+                }
+            ],
+        }
+
+
+class ManagedPreferences(ClientBound["DarwinClient[DarwinSymbolT_co]"], Generic[DarwinSymbolT_co]):
+    """
+    iOS MDM configuration, split by mechanism:
+
+    - ``profile`` : the Managed Preferences store + raw configuration profiles.
+    - ``restricted`` : the restrictions / MCFeature settings.
+
+    iOS-only: everything goes through ``MCProfileConnection`` / ``ManagedConfiguration.framework``,
+    which does not exist on macOS. Non-interactive install requires the calling process to be
+    entitled for profiled access.
+    """
+
+    def __init__(self, client: "DarwinClient[DarwinSymbolT_co]", user: str = "mobile") -> None:
+        self._client = client
+        self.profile: ManagedProfile[DarwinSymbolT_co] = ManagedProfile(client, user)
+        self.restricted: ManagedRestrictions[DarwinSymbolT_co] = ManagedRestrictions(client)

--- a/src/rpcclient/rpcclient/clients/ios/subsystems/preferences.py
+++ b/src/rpcclient/rpcclient/clients/ios/subsystems/preferences.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING, Generic
+
+from rpcclient.clients.darwin._types import DarwinSymbolT_co
+from rpcclient.clients.darwin.subsystems.preferences import Preferences
+from rpcclient.clients.ios.subsystems.managed_preferences import ManagedPreferences
+
+
+if TYPE_CHECKING:
+    from rpcclient.clients.darwin.client import DarwinClient
+
+
+class IosPreferences(Preferences[DarwinSymbolT_co], Generic[DarwinSymbolT_co]):
+    """Preferences utils - iOS also exposes the MDM managed store via ``managed``.
+
+    ``managed`` is iOS-only: it goes through ``MCProfileConnection`` /
+    ``ManagedConfiguration.framework``, which does not exist on macOS.
+    """
+
+    def __init__(self, client: "DarwinClient[DarwinSymbolT_co]") -> None:
+        super().__init__(client)
+        self.managed: ManagedPreferences[DarwinSymbolT_co] = ManagedPreferences(client)

--- a/src/rpcclient/tests/test_process_preferences.py
+++ b/src/rpcclient/tests/test_process_preferences.py
@@ -1,0 +1,55 @@
+import pytest
+
+from rpcclient.clients.darwin.client import DarwinClient
+
+
+pytestmark = pytest.mark.darwin
+
+SCRATCH_DOMAIN = "com.rpcclient.process_preferences_test"
+
+
+async def test_bundle_id(client: DarwinClient) -> None:
+    """Process.bundle_id() (csops CS_OPS_IDENTITY) returns the process's code-signing identity."""
+    process = await client.processes.get_by_pid(await client.get_pid())
+    bundle_id = await process.bundle_id()
+    assert isinstance(bundle_id, str) and bundle_id
+
+
+async def test_environ_is_mapping(client: DarwinClient) -> None:
+    process = await client.processes.get_by_pid(await client.get_pid())
+    assert isinstance(await process.environ(), dict)
+
+
+async def test_preferences_own_domain(client: DarwinClient) -> None:
+    """preferences() with no argument resolves to the process's own bundle-id domain."""
+    process = await client.processes.get_by_pid(await client.get_pid())
+    prefs = process.preferences()
+    assert await prefs.application_id() == await process.bundle_id()
+
+
+async def test_preferences_path_matches_container(client: DarwinClient) -> None:
+    """path() is <container>/Library/Preferences/<domain>.plist for the target."""
+    process = await client.processes.get_by_pid(await client.get_pid())
+    prefs = process.preferences(SCRATCH_DOMAIN)
+    assert await prefs.path() == f"{await prefs.container()}/Library/Preferences/{SCRATCH_DOMAIN}.plist"
+
+
+async def test_preferences_roundtrip(client: DarwinClient) -> None:
+    """set / get / set_dict / remove / clear on a scratch domain, resolved as the process; path() exists."""
+    process = await client.processes.get_by_pid(await client.get_pid())
+    prefs = process.preferences(SCRATCH_DOMAIN)
+    try:
+        await prefs.set("key", 42)
+        assert await prefs.get("key") == 42
+
+        await prefs.set_dict({"a": 1, "b": [1, 2, 3]})
+        assert await prefs.get_dict() == {"a": 1, "b": [1, 2, 3]}
+
+        # the value physically lands at the fully-resolved path()
+        assert await client.fs.read_file(await prefs.path())
+
+        await prefs.remove("a")
+        assert await prefs.get_dict() == {"b": [1, 2, 3]}
+    finally:
+        await prefs.clear()
+    assert await prefs.get_dict() == {}


### PR DESCRIPTION
Two related preferences changes.

## 1 — `fix`: default cfpreferences hostname to `AnyHost`

The `p.preferences.cf.*` wrappers defaulted `hostname` to `kCFPreferencesCurrentHost`, which scopes reads/writes to the **per-device ByHost store** — `…/Library/Preferences/ByHost/<domain>.<host-UUID>.plist`.

Ordinary apps and daemons, the high-level `CFPreferencesCopyAppValue`, and `NSUserDefaults` all use `kCFPreferencesAnyHost` → the plain `<domain>.plist`. With the old default:

- `cf.get_value(app, key)` **missed** keys stored in the common AnyHost domain (returned `None` for values that plainly exist).
- `cf.set(...)` wrote into a ByHost file that `defaults` / `CopyAppValue` never read back.

Defaulting to `AnyHost` makes the low-level wrappers agree with the high-level API and the common case. Callers needing per-host scope can still pass `hostname=kCFPreferencesCurrentHost` explicitly. `username` is unchanged.

## 2 — `feat`: managed-preferences (MDM) subsystem

Adds `p.preferences.managed`, mirroring the `cf` API (`get_value` / `get_dict` / `get_keys` / `set` / `set_dict` / `remove` / `clear`) for the MDM **Managed Preferences** store. cfprefsd merges that store at the **front** of the read search list, so a managed key wins over anything an app writes via `preferences.cf`.

- **Reads** come off the effective plists under `/Library/Managed Preferences[/<user>]/<application_id>.plist`.
- **Writes** go through **profiled** — `-[MCProfileConnection installProfileData:outError:]` / `removeProfileWithIdentifier:`, the same path Settings and `mdmclient` use — by installing/removing a `com.apple.ManagedClient.preferences` (MCX "Custom Settings") profile. The store is **not** poked directly: profiled owns it, so writing the files behind it would be untracked and clobbered.

Raw primitives are also exposed: `install_profile(data)` / `remove_profile(identifier)` / `is_profile_installed(identifier)`.

```python
# force a managed value (builds + installs an MCX profile via profiled)
ident = p.preferences.managed.set("SBDisableHomeButton", True, "com.apple.springboard")
p.preferences.managed.get_dict("com.apple.springboard")   # read the effective managed plist
p.preferences.managed.clear("com.apple.springboard")      # remove_profile(ident)
```

Non-interactive install requires the calling process to be entitled for profiled access; otherwise the install is queued for user approval. `ruff` / pre-commit pass and the module imports and builds the MCX profile correctly; the on-device install path is not exercised in this repo's tests.
